### PR TITLE
Update Gson to 2.8.9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories{
 }
 
 dependencies{
-    implementation("com.google.code.gson:gson:2.8.1")
+    implementation("com.google.code.gson:gson:2.8.9")
 
     testImplementation("junit:junit:4.12")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.9.3")


### PR DESCRIPTION
Updates Gson to 2.8.9

This fixes [CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647)