### PR TITLE
Add 'getInteger' to Toml

### DIFF
--- a/src/main/java/de/thelooter/toml/Toml.java
+++ b/src/main/java/de/thelooter/toml/Toml.java
@@ -158,7 +158,13 @@ public class Toml {
 
   public Integer getInteger(String key) {
       Long val = getLong(key);
-      return val == null ? null : val.intValue();
+      if (val == null) {
+          return null;
+      }
+      if (val < Integer.MIN_VALUE || val > Integer.MAX_VALUE) {
+          throw new ArithmeticException("Integer overflow: value " + val + " is outside of Integer range");
+      }
+      return val.intValue();
   }
 
   public Integer getInteger(String key, Integer defaultValue) {

--- a/src/main/java/de/thelooter/toml/Toml.java
+++ b/src/main/java/de/thelooter/toml/Toml.java
@@ -156,6 +156,16 @@ public class Toml {
     return val == null ? defaultValue : val;
   }
 
+  public Integer getInteger(String key) {
+      Long val = getLong(key);
+      return val == null ? null : val.intValue();
+  }
+
+  public Integer getInteger(String key, Integer defaultValue) {
+      Integer val = getInteger(key);
+      return val == null ? defaultValue : val;
+  }
+
   /**
    * @param key a TOML key
    * @param <T> type of list items

--- a/src/test/java/de/thelooter/toml/NumberTest.java
+++ b/src/test/java/de/thelooter/toml/NumberTest.java
@@ -4,6 +4,7 @@ package de.thelooter.toml;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class NumberTest {
@@ -26,6 +27,41 @@ public class NumberTest {
     Toml toml = new Toml().read("a = +1001\nb = 1001");
 
     assertEquals(toml.getLong("b"), toml.getLong("a"));
+  }
+
+  @Test
+  public void should_get_integer() {
+    Toml toml = new Toml().read("b = 1001");
+
+    assertEquals(1001, toml.getInteger("b").intValue());
+  }
+
+  @Test
+  public void should_get_negative_integer() {
+    Toml toml = new Toml().read("b = -1001");
+
+    assertEquals(-1001, toml.getInteger("b").intValue());
+  }
+
+  @Test
+  public void should_get_null_integer() {
+    Toml toml = new Toml().read("b = -1001");
+
+    assertNull(toml.getInteger("J"));
+  }
+
+  @Test
+  public void should_get_default_integer() {
+    Toml toml = new Toml().read("b = -1001");
+
+    assertEquals(74, toml.getInteger("J", 74).intValue());
+  }
+
+  @Test
+  public void should_get_integer_with_plus_sign() {
+    Toml toml = new Toml().read("a = +1001\nb = 1001");
+
+    assertEquals(toml.getInteger("b"), toml.getInteger("a"));
   }
 
   @Test
@@ -60,12 +96,19 @@ public class NumberTest {
     assertEquals(-2e-2, toml.getDouble("negative"), 0.0);
     assertEquals(6.626D * Math.pow(10, -34), toml.getDouble("fractional"), 0.0);
   }
-  
+
+  @Test
+  public void should_get_number_with_underscores() {
+    Toml toml = new Toml().read("val = 100_000_000");
+
+    assertEquals(100000000L, toml.getLong("val").longValue());
+  }
+
   @Test
   public void should_get_integer_with_underscores() {
     Toml toml = new Toml().read("val = 100_000_000");
-    
-    assertEquals(100000000L, toml.getLong("val").intValue());
+
+    assertEquals(100000000, toml.getInteger("val").intValue());
   }
   
   @Test


### PR DESCRIPTION
Commits adapted from @velo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced two new methods for retrieving integer values from TOML data: `getInteger(String key)` and `getInteger(String key, Integer defaultValue)`.
  
- **Tests**
	- Added multiple test cases to validate the new integer retrieval methods under various scenarios, including handling null values and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->